### PR TITLE
Add build step instructions and env fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ targetRIR = 4.5 - ((4.0) / (mesoLength - 1)) * (week - 1)
 
 1. **Open `index.html`** in a modern browser
 2. **Create a `.env` file** based on `.env.example` and add your `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
-3. **Set Volume Landmarks**: Configure MV/MEV/MAV/MRV for each muscle
-4. **Daily Use**: Submit set feedback after each exercise
-5. **Weekly Review**: Check deload need and frequency optimization
-6. **Export Data**: Generate summaries for tracking progress
+3. **Run `npm run build`** so Parcel injects your Supabase credentials into the bundle.
+4. **Set Volume Landmarks**: Configure MV/MEV/MAV/MRV for each muscle
+5. **Daily Use**: Submit set feedback after each exercise
+6. **Weekly Review**: Check deload need and frequency optimization
+7. **Export Data**: Generate summaries for tracking progress
 
 ## 📱 User Interface
 

--- a/js/core/db.js
+++ b/js/core/db.js
@@ -1,7 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supaUrl = process.env.SUPABASE_URL;
-const supaKey = process.env.SUPABASE_ANON_KEY;
+const supaUrl = process.env.SUPABASE_URL ||
+  (typeof window !== 'undefined' ? window.SUPABASE_URL : undefined);
+const supaKey = process.env.SUPABASE_ANON_KEY ||
+  (typeof window !== 'undefined' ? window.SUPABASE_ANON_KEY : undefined);
 const supa = createClient(supaUrl, supaKey);
 
 /* ---------- Auth helpers ---------- */


### PR DESCRIPTION
## Summary
- document running `npm run build` after creating `.env`
- allow database module to read `window` variables if the environment values are undefined

## Testing
- `npm run build` *(fails: parcel not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c526d24a88323909186fb013b8523