### PR TITLE
Fix Quick Start numbers layout

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1145,6 +1145,7 @@ button.small {
   max-width: 480px;        /* comfortable line length */
   padding-left: 1.4rem;    /* slight indent for numbers */
   list-style-position: inside;
+  text-align: left;        /* align numbers with text */
 }
 
 /* --- End of Styles --- */


### PR DESCRIPTION
## Summary
- ensure the Quick-Start Guide ordered list aligns numbers with text

## Testing
- `npm run lint` *(fails: couldn't find eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a2095b08323ac8170662671cb4c