### PR TITLE
Fix Jest environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "buffer": "^6.0.3",
     "eslint": "^8.57.1",
     "jest": "^30.0.0",
+    "jest-environment-jsdom": "^30.0.0",
     "parcel": "^2.15.2",
     "prettier": "^3.5.3"
   },


### PR DESCRIPTION
## Summary
- include `jest-environment-jsdom` as a dev dependency so Jest can find jsdom

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6850346887748323976a730c397fcc71