### PR TITLE
Fix service worker & chart init

### DIFF
--- a/js/utils/performance.js
+++ b/js/utils/performance.js
@@ -619,8 +619,15 @@ class PerformanceManager {
   /**
    * Setup service worker
   */ setupServiceWorker() {
-    // avoid interfering with Parcel dev server
-    if (location.hostname === "localhost") return;
+    const isLocal = ["localhost", "127.0.0.1"].includes(location.hostname);
+
+    if (isLocal && "serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => regs.forEach((r) => r.unregister()));
+    }
+
+    if (isLocal) return;
 
     if ("serviceWorker" in navigator) {
       navigator.serviceWorker

--- a/main.js
+++ b/main.js
@@ -2,6 +2,13 @@
 import "./js/core/db.js";
 import "./js/ui/globals.js";
 import "./js/core/trainingState.js";
+import { initChart } from "./js/ui/chartManager.js";
 
 // App initialization
 console.log("RP Toolkit initialized");
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initChart);
+} else {
+  initChart();
+}


### PR DESCRIPTION
## Summary
- disable service worker on localhost and unregister existing instances
- initialise the weekly volume chart after DOM is ready

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685048e98160832388d037833e2bbff9