### PR TITLE
Fix volume bars and sync chest card with state

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1224,11 +1224,65 @@ button.small {
 /* --- End of Styles --- */
 
 /* Muscle Volume Cards */
-.muscle-card{border:1px solid #e5e7eb;border-radius:8px;padding:16px;margin:8px 0;background:#fff}
-.muscle-card h3{display:flex;justify-content:space-between;margin:0;font-size:18px;color:#374151}
-.vol-badge{padding:4px 8px;border-radius:4px;font-weight:600;font-size:14px}
-.vol-badge.optimal{background:#dcfce7;color:#166534}
-.vol-bar{position:relative;height:8px;background:#f3f4f6;border-radius:4px;margin:8px 0}
-.vol-fill{height:100%;background:#0059ff;border-radius:4px;transition:width .3s}
-.landmark{position:absolute;top:-2px;width:2px;height:12px;background:#6b7280}
-.card-ftr{text-align:center;font-size:12px;color:#6b7280}
+.muscle-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+  margin: 8px 0;
+  background: #fff;
+}
+.muscle-card h3 {
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+  font-size: 18px;
+  color: #374151;
+}
+.vol-badge {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 14px;
+}
+.vol-badge.optimal {
+  background: #dcfce7;
+  color: #166534;
+}
+.vol-bar {
+  position: relative;
+  height: 8px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  margin: 8px 0;
+}
+.vol-fill {
+  height: 100%;
+  background: #0059ff;
+  border-radius: 4px;
+  transition: width 0.3s;
+}
+.volume-bar {
+  position: relative;
+  height: 8px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  margin: 8px 0;
+}
+.volume-fill {
+  height: 100%;
+  background: #0059ff;
+  border-radius: 4px;
+  transition: width 0.3s;
+}
+.landmark {
+  position: absolute;
+  top: -2px;
+  width: 2px;
+  height: 12px;
+  background: #6b7280;
+}
+.card-ftr {
+  text-align: center;
+  font-size: 12px;
+  color: #6b7280;
+}

--- a/index.html
+++ b/index.html
@@ -122,11 +122,11 @@
         <!---- Muscle cards container (below the chart) -->
         <section id="muscleCards">
           <div class="muscle-card" data-muscle="chest">
-            <h3>Chest <span class="vol-badge optimal">14&nbsp;sets</span></h3>
-            <div class="vol-bar">
-              <div class="vol-fill" style="width:65%"></div>
-              <div class="landmark" style="left:40%"></div>
-              <div class="landmark" style="left:75%"></div>
+            <h3>Chest <span class="vol-badge">14&nbsp;sets</span></h3>
+            <div class="volume-bar">
+              <div class="volume-fill"></div>
+              <div class="landmark" style="left: 40%"></div>
+              <div class="landmark" style="left: 75%"></div>
             </div>
             <div class="card-ftr">MEV 8 | MAV 16 | MRV 22</div>
           </div>

--- a/js/core/trainingState.js
+++ b/js/core/trainingState.js
@@ -52,6 +52,14 @@ class TrainingState {
       this.baselineStrength[muscle] = 100; // Default baseline load (kg)
     });
 
+    this.weeklyVolume = {};
+    Object.keys(this.volumeLandmarks).forEach((m) => {
+      this.weeklyVolume[m] = {
+        current: this.currentWeekSets[m],
+        ...this.volumeLandmarks[m],
+      };
+    });
+
     // Performance tracking for deload detection
     this.consecutiveMRVWeeks = 0;
 
@@ -98,14 +106,22 @@ class TrainingState {
   // Update weekly sets for a muscle
   updateWeeklySets(muscle, sets) {
     this.currentWeekSets[muscle] = Math.max(0, sets);
+    if (this.weeklyVolume[muscle])
+      this.weeklyVolume[muscle].current = this.currentWeekSets[muscle];
     this.saveState();
+    if (typeof window !== "undefined" && window.updateAllDisplays)
+      window.updateAllDisplays();
   }
 
   // Add sets to a muscle
   addSets(muscle, additionalSets) {
     this.currentWeekSets[muscle] += additionalSets;
     this.currentWeekSets[muscle] = Math.max(0, this.currentWeekSets[muscle]);
+    if (this.weeklyVolume[muscle])
+      this.weeklyVolume[muscle].current = this.currentWeekSets[muscle];
     this.saveState();
+    if (typeof window !== "undefined" && window.updateAllDisplays)
+      window.updateAllDisplays();
   }
   // Check if deload is needed
   shouldDeload() {
@@ -280,6 +296,7 @@ class TrainingState {
       resensitizationPhase: this.resensitizationPhase,
       currentWeekSets: this.currentWeekSets,
       lastWeekSets: this.lastWeekSets,
+      weeklyVolume: this.weeklyVolume,
       consecutiveMRVWeeks: this.consecutiveMRVWeeks,
       recoverySessionsThisWeek: this.recoverySessionsThisWeek,
       totalMusclesNeedingRecovery: this.totalMusclesNeedingRecovery,

--- a/js/ui/globals.js
+++ b/js/ui/globals.js
@@ -1401,14 +1401,29 @@ onAuth((sess) => {
 });
 
 /* Temporary stubs to satisfy ESLint — replace with real logic */
-export function showSystemMessage(msg = '') {
-  console.warn('showSystemMessage stub:', msg);
+export function showSystemMessage(msg = "") {
+  console.warn("showSystemMessage stub:", msg);
 }
 export function createSystemOutput(data = {}) {
-  console.warn('createSystemOutput stub:', data);
+  console.warn("createSystemOutput stub:", data);
 }
 export function updateAllDisplays() {
-  /* TODO: refresh UI widgets when state changes */
+  const c = document.querySelector('[data-muscle="chest"]');
+  const d = trainingState.weeklyVolume?.Chest;
+  if (!c || !d) return;
+  const b = c.querySelector(".vol-badge");
+  b.textContent = `${d.current} sets`;
+  c.querySelector(".volume-fill").style.width =
+    `${Math.min((d.current / d.MRV) * 100, 100)}%`;
+  const col =
+    d.current >= d.MRV
+      ? "#ef4444"
+      : d.current >= d.MAV
+        ? "#f59e0b"
+        : d.current >= d.MEV
+          ? "#10b981"
+          : "#6b7280";
+  b.style.backgroundColor = col;
 }
 
 console.log("globals loaded – auth handlers ready");


### PR DESCRIPTION
## Summary
- wire chest card to trainingState volume data
- expose auto updates in trainingState
- patch updateAllDisplays to refresh chest card
- add CSS rules for volume bars

## Testing
- `npm test` *(fails: Cannot find module jest.js)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx prettier -w index.html css/main.css js/core/trainingState.js js/ui/globals.js`

------
https://chatgpt.com/codex/tasks/task_e_68504ef0e0dc83238e03a5753af4c329