### PR TITLE
Fix auth modal element issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1052,7 +1052,9 @@
     <!-- Load modules and initialize -->
 
     <!-- Auth Modal Container -->
-    <div id="authRoot"></div>
+    <div id="authRoot">
+      <div id="authModal" class="modal hidden"></div>
+    </div>
 
     <!-- then scripts -->
     <script type="module" src="./js/ui/loadPartials.js"></script>

--- a/js/ui/globals.js
+++ b/js/ui/globals.js
@@ -1340,7 +1340,6 @@ import { signIn, signUp, signOut, onAuth, supa } from "../core/db.js";
 // DOM elements for auth
 const authEmail = document.getElementById("authEmail");
 const authPass = document.getElementById("authPass");
-const authModal = document.getElementById("authModal");
 
 // Helper function for auth loading state
 function setAuthLoading(isLoading) {
@@ -1363,7 +1362,7 @@ window.handleSignIn = async function () {
   const { error, data } = await signIn(email, pass);
   setAuthLoading(false);
   if (error) return alert(error.message);
-  authModal.classList.add("hidden"); // hide modal on success
+  document.getElementById("authModal")?.classList.add("hidden"); // hide modal on success
   console.log("Logged-in session:", data);
 };
 
@@ -1378,7 +1377,7 @@ window.handleSignUp = async function () {
   const { error, data } = await signUp(email, pass);
   setAuthLoading(false);
   if (error) return alert(error.message);
-  authModal.classList.add("hidden");
+  document.getElementById("authModal")?.classList.add("hidden");
   console.log("Signed-up session:", data);
 };
 
@@ -1387,12 +1386,13 @@ window.handleSignUp = async function () {
  */
 window.handleSignOut = async function () {
   await supa.auth.signOut();
-  authModal.classList.remove("hidden");
+  document.getElementById("authModal")?.classList.remove("hidden");
 };
 
 // Handle authentication state changes
 onAuth((sess) => {
-  document.getElementById("authModal").classList.toggle("hidden", !!sess);
+  const modal = document.getElementById("authModal");
+  modal?.classList.toggle("hidden", !!sess);
 
   const signOutBtn = document.getElementById("signOutBtn");
   if (signOutBtn) signOutBtn.style.display = sess ? "inline-block" : "none";


### PR DESCRIPTION
## Summary
- add auth modal placeholder markup in `index.html`
- re-query modal element in sign-out handler so it always exists

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_685051a0be488323972babea00f949f4