### PR TITLE
Fix auth callback crash on init

### DIFF
--- a/js/core/db.js
+++ b/js/core/db.js
@@ -21,5 +21,8 @@ export async function signOut() {
 }
 
 export function onAuth(callback) {
-  return supa.auth.onAuthStateChange((_event, session) => callback(session));
+  return supa.auth.onAuthStateChange((_e, s) => {
+    console.log("onAuth change:", s);
+    callback(s);
+  });
 }

--- a/js/ui/globals.js
+++ b/js/ui/globals.js
@@ -1397,15 +1397,17 @@ window.handleSignOut = async function () {
 
 // Handle authentication state changes
 onAuth((sess) => {
-  const modal = document.getElementById("authModal");
-  console.log("onAuth authModal:", modal, "ready:", document.readyState);
-  if (modal) modal.classList.toggle("hidden", !!sess);
-  else console.warn("authModal missing in onAuth");
-
-  const signOutBtn = document.getElementById("signOutBtn");
-  if (signOutBtn) signOutBtn.style.display = sess ? "inline-block" : "none";
-
-  console.log("Auth session", sess);
+  try {
+    const modal = document.getElementById("authModal");
+    console.log("onAuth authModal:", modal, "ready:", document.readyState);
+    if (modal) modal.classList.toggle("hidden", !!sess);
+    else console.warn("authModal missing in onAuth");
+    const signOutBtn = document.getElementById("signOutBtn");
+    if (signOutBtn) signOutBtn.style.display = sess ? "inline-block" : "none";
+    console.log("Auth session", sess);
+  } catch (err) {
+    console.error("onAuth callback failed:", err);
+  }
 });
 
 /* Temporary stubs to satisfy ESLint — replace with real logic */


### PR DESCRIPTION
## Summary
- log auth state changes in db.js
- wrap auth callback in try/catch to avoid DOM crashes

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68505c63fca8832392999977800d314f