### PR TITLE
Bundle Chart.js locally

### DIFF
--- a/docs/ProgramDesignWorkspace.99e626fb.js
+++ b/docs/ProgramDesignWorkspace.99e626fb.js
@@ -6799,17 +6799,14 @@
               });
           }
           loadAdvancedFeatures() {
-            if (
-              !window.Chart &&
-              !document.querySelector('script[src*="chart.js"]')
-            ) {
-              let e = document.createElement("script");
-              (e.src = "https://cdn.jsdelivr.net/npm/chart.js"),
-                (e.onload = () => {
-                  console.log("\uD83D\uDCC8 Chart.js loaded on demand"),
+            if (!window.Chart) {
+              import("chart.js/auto")
+                .then((e) => {
+                  (window.Chart = e.default),
+                    console.log("\uD83D\uDCC8 Chart.js loaded on demand"),
                     this.initializeCharts();
-                }),
-                document.head.appendChild(e);
+                })
+                .catch((e) => console.error("Failed to load Chart.js", e));
             }
           }
           optimizeDOMChanges(e) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,6 @@
       content="Advanced AI-powered training intelligence system for optimal workout programming and progression"
     />
     <link rel="icon" href="favicon.78009137.ico" />
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="ProgramDesignWorkspace.64e9132c.css" />
     <style>
       * {

--- a/js/utils/performance.js
+++ b/js/utils/performance.js
@@ -385,15 +385,15 @@ class PerformanceManager {
    * Load advanced features
    */
   loadAdvancedFeatures() {
-    // Load Chart.js only when advanced section is opened
-    if (!window.Chart && !document.querySelector('script[src*="chart.js"]')) {
-      const script = document.createElement("script");
-      script.src = "https://cdn.jsdelivr.net/npm/chart.js";
-      script.onload = () => {
-        console.log("📈 Chart.js loaded on demand");
-        this.initializeCharts();
-      };
-      document.head.appendChild(script);
+    // Dynamically import Chart.js when advanced section is opened
+    if (!window.Chart) {
+      import("chart.js/auto")
+        .then((module) => {
+          window.Chart = module.default;
+          console.log("📈 Chart.js loaded on demand");
+          this.initializeCharts();
+        })
+        .catch((err) => console.error("Failed to load Chart.js", err));
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0",
-        "chart.js": "^4.4.9"
+        "chart.js": "^4.5.0"
       },
       "devDependencies": {
         "@parcel/packager-raw-url": "^2.15.2",
@@ -4701,9 +4701,9 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
-      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0",
-    "chart.js": "^4.4.9"
+    "chart.js": "^4.5.0"
   },
   "targets": {
     "default": {


### PR DESCRIPTION
## Summary
- depend on Chart.js 4.5 via npm
- load Chart.js on demand using a dynamic import
- remove CDN Chart.js references from static files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68506631dbb88323b9aa4674d06a0780