### PR TITLE
Add glutes and deload load reduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
                 <option value="Chest">Chest</option>
                 <option value="Back">Back</option>
                 <option value="Quads">Quads</option>
+                <option value="Glutes">Glutes</option>
                 <option value="Hamstrings">Hamstrings</option>
                 <option value="Shoulders">Shoulders</option>
                 <option value="Biceps">Biceps</option>
@@ -428,6 +429,7 @@
                 <option value="Chest">Chest</option>
                 <option value="Back">Back</option>
                 <option value="Quads">Quads</option>
+                <option value="Glutes">Glutes</option>
                 <option value="Hamstrings">Hamstrings</option>
                 <option value="Shoulders">Shoulders</option>
                 <option value="Biceps">Biceps</option>
@@ -653,8 +655,9 @@
                 <select id="liveMuscle">
                   <option value="Chest">Chest</option>
                   <option value="Back">Back</option>
-                  <option value="Quads">Quads</option>
-                  <option value="Hamstrings">Hamstrings</option>
+                <option value="Quads">Quads</option>
+                <option value="Glutes">Glutes</option>
+                <option value="Hamstrings">Hamstrings</option>
                   <option value="Shoulders">Shoulders</option>
                   <option value="Biceps">Biceps</option>
                   <option value="Triceps">Triceps</option>

--- a/js/algorithms/effort.js
+++ b/js/algorithms/effort.js
@@ -523,17 +523,26 @@ function simulateWeeklyRIRFeedback(muscles, week) {
     if (volumeStatus === "maximum") {
       jointAche = Math.floor(Math.random() * 3) + 1; // 1-3 (mild to pain)
       perfChange = Math.random() > 0.6 ? -1 : 0; // 40% chance of performance drop
-      lastLoad = trainingState.baselineStrength[muscle] * 0.95; // 5% strength drop
+      lastLoad =
+        trainingState.baselineStrength[muscle] *
+        trainingState.loadReduction *
+        0.95; // 5% strength drop
       soreness = Math.floor(Math.random() * 2) + 2; // 2-3 (moderate to high)
     } else if (volumeStatus === "high") {
       jointAche = Math.floor(Math.random() * 2); // 0-1 (none to mild)
       perfChange = Math.random() > 0.8 ? -1 : Math.random() > 0.5 ? 0 : 1; // Mixed performance
-      lastLoad = trainingState.baselineStrength[muscle] * 0.98; // 2% strength drop
+      lastLoad =
+        trainingState.baselineStrength[muscle] *
+        trainingState.loadReduction *
+        0.98; // 2% strength drop
       soreness = Math.floor(Math.random() * 2) + 1; // 1-2 (mild to moderate)
     } else {
       jointAche = Math.floor(Math.random() * 2); // 0-1 (none to mild)
       perfChange = Math.random() > 0.7 ? 1 : 0; // 30% chance of PR
-      lastLoad = trainingState.baselineStrength[muscle] * 1.02; // 2% strength increase
+      lastLoad =
+        trainingState.baselineStrength[muscle] *
+        trainingState.loadReduction *
+        1.02; // 2% strength increase
       soreness = Math.floor(Math.random() * 2); // 0-1 (none to mild)
     }
 

--- a/js/ui/globals.js
+++ b/js/ui/globals.js
@@ -289,7 +289,7 @@ window.analyzeDeload = function () {
     output.innerHTML = `
       <strong>Deload Recommended</strong><br>
       Reasons: ${analysis.reasons.join(", ")}<br>
-      <em>Take 1 week at 50% volume + 25-50% load reduction</em>
+      <em>Take 1 week at 50% volume and 50% of normal load</em>
     `;
     output.className = "result warning active";
 
@@ -297,7 +297,7 @@ window.analyzeDeload = function () {
     setTimeout(() => {
       if (
         confirm(
-          "Start deload phase now? This will reduce all muscle volumes to 50% of MEV.",
+          "Start deload phase now? This will reduce all muscle volumes to 50% of MEV and loads to 50% of normal.",
         )
       ) {
         trainingState.startDeload();


### PR DESCRIPTION
## Summary
- expand volume landmarks with Glutes and tweak Chest/Quad values
- implement deload load reduction logic in TrainingState
- apply load multiplier inside effort feedback calculations
- show deload load reduction in UI messages
- update UI selects to include Glutes

## Testing
- `npm test` *(fails: cannot find module jest)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68506a7bab448323a8d1aa04ef1ea3c3