### PR TITLE
Implement phase UI utilities and paint timing log

### DIFF
--- a/css/phases.css
+++ b/css/phases.css
@@ -1,0 +1,10 @@
+.level-beginner  details[data-level="intermediate"],
+.level-beginner  details[data-level="advanced"],
+.level-intermediate details[data-level="advanced"] {
+  display: none;
+}
+.phase-blurb {
+  font-size: .85rem;
+  color: #64748b;
+  margin-top: .25rem;
+}

--- a/js/core/trainingState.js
+++ b/js/core/trainingState.js
@@ -39,6 +39,7 @@ class TrainingState {
     this.deloadPhase = false;
     this.resensitizationPhase = false;
     this.loadReduction = 1;
+    this.userLevel = 'beginner';
 
     // Current week data
     this.currentWeekSets = {};
@@ -311,6 +312,7 @@ class TrainingState {
       consecutiveMRVWeeks: this.consecutiveMRVWeeks,
       recoverySessionsThisWeek: this.recoverySessionsThisWeek,
       totalMusclesNeedingRecovery: this.totalMusclesNeedingRecovery,
+      userLevel: this.userLevel,
     };
 
     localStorage.setItem("rp-training-state", JSON.stringify(state));

--- a/js/ui/experienceToggle.js
+++ b/js/ui/experienceToggle.js
@@ -1,0 +1,14 @@
+import trainingState from '../core/trainingState.js';
+
+export function setExperienceLevel(level) {
+  trainingState.userLevel = level;
+  document.body.className = 'level-' + trainingState.userLevel;
+}
+
+export function initExperienceToggle(id = 'experienceToggle') {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener('change', (e) => {
+    setExperienceLevel(e.target.value);
+  });
+}

--- a/js/ui/phaseSections.js
+++ b/js/ui/phaseSections.js
@@ -1,0 +1,38 @@
+export default function renderPhaseSections(phases, rootId = 'phaseSections') {
+  const root = typeof rootId === 'string' ? document.getElementById(rootId) : rootId;
+  if (!root || !Array.isArray(phases)) return;
+
+  root.innerHTML = '';
+
+  function createButton(id) {
+    const btn = document.createElement('button');
+    btn.id = id;
+    btn.textContent = id.replace(/^btn/, '').replace(/([A-Z])/g, ' $1').trim();
+    return btn;
+  }
+
+  phases.forEach((phase) => {
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = phase.title;
+    details.appendChild(summary);
+    details.dataset.level = phase.level;
+
+    if (Array.isArray(phase.buttons)) {
+      phase.buttons.forEach((id) => {
+        details.appendChild(createButton(id));
+      });
+    }
+
+    if (phase.blurb) {
+      const blurb = document.createElement('div');
+      blurb.className = 'phase-blurb';
+      blurb.textContent = phase.blurb;
+      details.appendChild(blurb);
+    }
+
+    root.appendChild(details);
+  });
+
+  console.info('✅ Buttons rendered:', root.querySelectorAll('button').length);
+}

--- a/js/utils/performance.js
+++ b/js/utils/performance.js
@@ -165,6 +165,11 @@ class PerformanceManager {
     }
   }
 
+  handlePaintTiming(entry) {
+    // temporary stub – logs paint events
+    console.debug(`\uD83C\uDFA8 Paint: ${entry.name}`, entry.startTime.toFixed(1));
+  }
+
   /**
    * Setup memory monitoring
    */


### PR DESCRIPTION
## Summary
- stub `handlePaintTiming` in performance manager
- store `userLevel` in training state
- provide phase section UI helpers
- handle user experience level toggle
- add progressive disclosure styles

## Testing
- `npx eslint -c .eslintrc.json "js/**"` *(fails: Module needs import attribute)*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6850bd0521388323a544a1177999691c