### PR TITLE
Handle missing frequency landmarks

### DIFF
--- a/js/__tests__/optimizeFrequency.error.test.js
+++ b/js/__tests__/optimizeFrequency.error.test.js
@@ -1,0 +1,25 @@
+import trainingState from '../core/trainingState.js';
+import { btnOptimizeFrequency } from '../ui/additionalHandlers.js';
+import { calculateOptimalFrequency } from '../calculators/unified.js';
+
+let originalLandmarks;
+
+beforeAll(() => {
+  originalLandmarks = JSON.parse(JSON.stringify(trainingState.volumeLandmarks));
+});
+
+afterEach(() => {
+  trainingState.volumeLandmarks = JSON.parse(JSON.stringify(originalLandmarks));
+});
+
+test('optimizeFrequency – no landmarks => handled gracefully', () => {
+  trainingState.volumeLandmarks = {};
+  expect(() => btnOptimizeFrequency()).not.toThrow();
+});
+
+test('calculateOptimalFrequency throws when landmarks missing', () => {
+  const original = trainingState.volumeLandmarks.Chest;
+  trainingState.volumeLandmarks.Chest = {};
+  expect(() => calculateOptimalFrequency('Chest')).toThrow('Missing volume landmarks');
+  trainingState.volumeLandmarks.Chest = original;
+});

--- a/js/algorithms/fatigue.js
+++ b/js/algorithms/fatigue.js
@@ -344,6 +344,9 @@ function calculateOptimalFrequency(muscle, constraints = {}) {
 
   const volume = currentVolume || trainingState.currentWeekSets[muscle];
   const landmarks = trainingState.volumeLandmarks[muscle];
+  if (!landmarks || landmarks.MAV === undefined) {
+    throw new Error(`Missing volume landmarks for muscle: ${muscle}`);
+  }
 
   // Base frequency recommendations by training age
   const baseFrequencies = {

--- a/js/calculators/unified.js
+++ b/js/calculators/unified.js
@@ -1,7 +1,6 @@
-import * as volume from "../algorithms/volume.js";
-import * as fatigue from "../algorithms/fatigue.js";
-
-export const scoreStimulus = volume.scoreStimulus;
-export const processWeeklyVolumeProgression = volume.processWeeklyVolumeProgression;
-export const calculateOptimalFrequency = fatigue.calculateOptimalFrequency;
-export const analyzeFrequency = fatigue.analyzeFrequency;
+export * from "../algorithms/volume.js";
+export {
+  calculateOptimalFrequency,
+  analyzeFrequency,
+  isHighFatigue,
+} from "../algorithms/fatigue.js";

--- a/js/ui/additionalHandlers.js
+++ b/js/ui/additionalHandlers.js
@@ -6,10 +6,25 @@ import {
 import { processRPData } from "../core/rpAlgorithms.js";
 
 export async function btnOptimizeFrequency() {
-  const muscles = Object.keys(trainingState.volumeLandmarks);
-  const results = muscles.map((m) =>
-    calculateOptimalFrequency(m, { currentVolume: trainingState.currentWeekSets[m] })
-  );
+  const volumeLandmarks = trainingState.volumeLandmarks;
+  if (!volumeLandmarks || Object.keys(volumeLandmarks).length === 0) {
+    console.warn("btnOptimizeFrequency: No volume landmarks available");
+    return;
+  }
+  const muscles = Object.keys(volumeLandmarks);
+  const results = [];
+  muscles.forEach((m) => {
+    const lm = volumeLandmarks[m];
+    if (!lm || lm.MAV === undefined) {
+      console.warn(`btnOptimizeFrequency: Missing landmarks for ${m}`);
+      return;
+    }
+    results.push(
+      calculateOptimalFrequency(m, {
+        currentVolume: trainingState.currentWeekSets[m],
+      }),
+    );
+  });
   const out = document.getElementById("freqOut") || document.body;
   out.innerHTML = `<pre>${JSON.stringify(results, null, 2)}</pre>`;
 }


### PR DESCRIPTION
## Summary
- add Jest tests for frequency optimization edge cases
- throw errors for missing volume landmarks
- guard `btnOptimizeFrequency` against missing landmarks
- re-export all calculator helpers via `unified.js`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6852000ee48c83239451616d4ef04d40