### PR TITLE
Add algorithm test coverage

### DIFF
--- a/js/__tests__/exerciseSelection.test.js
+++ b/js/__tests__/exerciseSelection.test.js
@@ -1,0 +1,22 @@
+import { selectOptimalExercises } from "../algorithms/exerciseSelection.js";
+
+describe("selectOptimalExercises", () => {
+  test("returns top cable flyes when equipment available", () => {
+    const res = selectOptimalExercises("chest", {
+      availableEquipment: ["barbell", "bench", "dumbbells", "cables", "incline_bench"],
+      trainingGoal: "hypertrophy",
+    });
+    expect(res[0].name).toBe("Cable Flyes");
+    expect(res).toHaveLength(5);
+  });
+
+  test("falls back to push ups with bodyweight only", () => {
+    const res = selectOptimalExercises("chest", { availableEquipment: ["bodyweight"] });
+    expect(res[0].name).toBe("Push Ups");
+  });
+
+  test("handles unknown muscle", () => {
+    const res = selectOptimalExercises("unknown", {});
+    expect(res[0].name).toBe("No exercises found");
+  });
+});

--- a/js/__tests__/fatigue.algorithms.test.js
+++ b/js/__tests__/fatigue.algorithms.test.js
@@ -1,0 +1,62 @@
+import trainingState from "../core/trainingState.js";
+import { isHighFatigue, calculateOptimalFrequency } from "../algorithms/fatigue.js";
+
+describe("isHighFatigue", () => {
+  test("detects low stimulus to fatigue ratio", () => {
+    const state = { repStrengthDrop: () => false };
+    const feedback = { soreness: 2, jointAche: 2, perfChange: 0, pump: 1, disruption: 0 };
+    expect(isHighFatigue("Chest", feedback, state)).toBe(true);
+  });
+
+  test("detects strength drop despite high SFR", () => {
+    const state = { repStrengthDrop: () => true };
+    const feedback = {
+      soreness: 0,
+      jointAche: 0,
+      perfChange: 0,
+      pump: 3,
+      disruption: 3,
+      lastLoad: 90,
+    };
+    expect(isHighFatigue("Chest", feedback, state)).toBe(true);
+  });
+
+  test("returns false when stimulus outweighs fatigue", () => {
+    const state = { repStrengthDrop: () => false };
+    const feedback = { soreness: 0, jointAche: 0, perfChange: 1, pump: 3, disruption: 3 };
+    expect(isHighFatigue("Chest", feedback, state)).toBe(false);
+  });
+});
+
+describe("calculateOptimalFrequency", () => {
+  let originalSets;
+
+  beforeAll(() => {
+    originalSets = { ...trainingState.currentWeekSets };
+  });
+
+  afterEach(() => {
+    trainingState.currentWeekSets = { ...originalSets };
+  });
+
+  test("computes frequency from current volume", () => {
+    trainingState.currentWeekSets.Chest = 12;
+    const result = calculateOptimalFrequency("Chest", { availableDays: 5 });
+    expect(result.recommendedFrequency).toBe(2);
+    expect(result.setsPerSession).toBe(6);
+  });
+
+  test("handles high volume and recovery capacity", () => {
+    trainingState.currentWeekSets.Chest = 20;
+    const result = calculateOptimalFrequency("Chest", {
+      availableDays: 6,
+      recoveryCapacity: "high",
+    });
+    expect(result.recommendedFrequency).toBe(4);
+    expect(result.setsPerSession).toBe(5);
+  });
+
+  test("throws for missing landmarks", () => {
+    expect(() => calculateOptimalFrequency("Unknown")).toThrow("Missing volume landmarks");
+  });
+});

--- a/js/__tests__/volume.algorithms.test.js
+++ b/js/__tests__/volume.algorithms.test.js
@@ -1,0 +1,84 @@
+import { autoSetIncrement, processWeeklyVolumeProgression } from "../algorithms/volume.js";
+
+function createMockState() {
+  return {
+    volumeLandmarks: {
+      Chest: { MV: 4, MEV: 6, MAV: 16, MRV: 20 },
+      Back: { MV: 6, MEV: 10, MAV: 20, MRV: 25 },
+    },
+    currentWeekSets: { Chest: 2, Back: 10 },
+    lastWeekSets: { Chest: 2, Back: 10 },
+    mrvHits: 0,
+    deloadStarted: false,
+    getWeeklySets(m) {
+      return this.currentWeekSets[m] || 0;
+    },
+    addSets(m, d) {
+      this.currentWeekSets[m] = (this.currentWeekSets[m] || 0) + d;
+    },
+    getVolumeStatus(m) {
+      const s = this.getWeeklySets(m);
+      const l = this.volumeLandmarks[m];
+      if (s < l.MV) return "low";
+      if (s < l.MEV) return "suboptimal";
+      if (s < l.MAV) return "optimal";
+      if (s < l.MRV) return "high";
+      return "maximum";
+    },
+    hitMRV() {
+      this.mrvHits++;
+    },
+    shouldDeload() {
+      return this.mrvHits >= 2;
+    },
+    startDeload() {
+      this.deloadStarted = true;
+    },
+    repStrengthDrop(m, lastLoad) {
+      return m === "Back" && lastLoad < 100;
+    },
+  };
+}
+
+describe("autoSetIncrement", () => {
+  test("adds a set when volume low and stimulus poor", () => {
+    const state = createMockState();
+    const result = autoSetIncrement(
+      "Chest",
+      { stimulus: { mmc: 1, pump: 1, disruption: 1 }, recoveryMuscle: "recovered" },
+      state,
+    );
+    expect(result).toEqual({ add: true, delta: 1 });
+  });
+});
+
+describe("processWeeklyVolumeProgression", () => {
+  test("processes sample weekly feedback", () => {
+    const state = createMockState();
+    const feedback = {
+      Chest: {
+        stimulus: { mmc: 1, pump: 1, disruption: 1 },
+        pump: 1,
+        disruption: 1,
+        soreness: 0,
+        jointAche: 0,
+        perfChange: 1,
+        recoveryMuscle: "recovered",
+      },
+      Back: {
+        stimulus: { mmc: 1, pump: 0, disruption: 1 },
+        pump: 0,
+        disruption: 1,
+        soreness: 3,
+        jointAche: 2,
+        perfChange: -1,
+        lastLoad: 90,
+      },
+    };
+    const result = processWeeklyVolumeProgression(feedback, state);
+    expect(result.deloadTriggered).toBe(false);
+    expect(result.mrvHits).toBe(1);
+    expect(state.currentWeekSets.Chest).toBe(3);
+    expect(result.progressionLog.Back.status).toBe("optimal");
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for fatigue algorithms
- add exercise selection tests
- add volume algorithm tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852da03ed0483238c01c7e42b1ecd6e