### PR TITLE
Fix undoLastSet test for ESM

### DIFF
--- a/__tests__/undoLastSet.test.js
+++ b/__tests__/undoLastSet.test.js
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 
+import { jest } from '@jest/globals';
+
 import { undoLastSet } from '../js/algorithms/workout.js';
 import { undoLastSetHandler } from '../js/ui/buttonHandlers.js';
 import trainingState from '../js/core/trainingState.js';
@@ -392,11 +394,12 @@ describe('UndoLastSet Handler Integration', () => {
     );
   });
 
-  test('should be exposed on window object', () => {
+  test('should be exposed on window object', async () => {
     expect(typeof undoLastSetHandler).toBe('function');
-    
+
     // Test if handler is properly exposed
-    const { undoLastSetHandler: importedHandler } = require('../js/ui/buttonHandlers.js');
+    const mod = await import('../js/ui/buttonHandlers.js');
+    const importedHandler = mod.undoLastSetHandler;
     expect(typeof importedHandler).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- fix undoLastSet test to import `jest` for ESM
- use dynamic import for undoLastSetHandler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68546c4ca89c83239e353ded245c40ed