### PR TITLE
Implement finish workout handler

### DIFF
--- a/buttons.json
+++ b/buttons.json
@@ -2,7 +2,7 @@
   "buttons": [
     {
       "id": "btnBeginnerPreset",
-      "label": "(no label)",
+      "label": "Beginner Preset",
       "section": "Phase 1 · Foundation Setup Beginner 4 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
@@ -12,7 +12,7 @@
     },
     {
       "id": "btnIntermediatePreset",
-      "label": "(no label)",
+      "label": "Intermediate Preset",
       "section": "Phase 1 · Foundation Setup Beginner 4 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
@@ -22,7 +22,7 @@
     },
     {
       "id": "btnAdvancedPreset",
-      "label": "(no label)",
+      "label": "Advanced Preset",
       "section": "Phase 1 · Foundation Setup Beginner 4 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
@@ -32,7 +32,7 @@
     },
     {
       "id": "btnSaveVolumeLandmarks",
-      "label": "(no label)",
+      "label": "Save Volume Landmarks",
       "section": "Phase 1 · Foundation Setup Beginner 4 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
@@ -162,8 +162,8 @@
     },
     {
       "id": "btnStartLiveSession",
-      "label": "(no label)",
-      "section": "Phase 4 · Daily Execution Beginner 4 actions ▼",
+      "label": "Start Live Session",
+      "section": "Phase 4 · Daily Execution Beginner 5 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
       "hasHandler": true,
@@ -172,8 +172,8 @@
     },
     {
       "id": "btnProcessWithRPAlgorithms",
-      "label": "(no label)",
-      "section": "Phase 4 · Daily Execution Beginner 4 actions ▼",
+      "label": "Process with RP Algorithms",
+      "section": "Phase 4 · Daily Execution Beginner 5 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
       "hasHandler": true,
@@ -182,8 +182,8 @@
     },
     {
       "id": "btnLogSet",
-      "label": "(no label)",
-      "section": "Phase 4 · Daily Execution Beginner 4 actions ▼",
+      "label": "Log Set",
+      "section": "Phase 4 · Daily Execution Beginner 5 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
       "hasHandler": true,
@@ -191,13 +191,13 @@
       "category": "other"
     },
     {
-      "id": "btnEndSession",
-      "label": "(no label)",
-      "section": "Phase 4 · Daily Execution Beginner 4 actions ▼",
+      "id": "btnUndoLastSet",
+      "label": "Undo Last Set",
+      "section": "Phase 4 · Daily Execution Beginner 5 actions ▼",
       "parentForm": "(no form)",
       "relatedInputs": 0,
-      "hasHandler": false,
-      "handlerName": "(none)",
+      "hasHandler": true,
+      "handlerName": "undoLastSetHandler",
       "category": "other"
     },
     {

--- a/js/algorithms/workout.js
+++ b/js/algorithms/workout.js
@@ -400,3 +400,30 @@ export function undoLastSet(session) {
     removedSet
   };
 }
+
+/**
+ * Finish the current workout session
+ * @param {Object|null} session - Workout session to finish (default trainingState.currentWorkout)
+ * @param {Object} state - Training state object (default trainingState)
+ * @returns {Object} - Finished workout session
+ */
+export function finishWorkout(session = null, state = trainingState) {
+  const workout = session || state.currentWorkout;
+  if (!workout) {
+    throw new Error('No active workout session');
+  }
+  if (workout.status !== 'active') {
+    throw new Error('Workout session is not active');
+  }
+
+  workout.status = 'completed';
+  workout.endTime = new Date().toISOString();
+
+  state.workoutHistory = state.workoutHistory || [];
+  state.workoutHistory.push(workout);
+  state.currentWorkout = null;
+
+  console.log('Workout session finished:', workout.id);
+
+  return workout;
+}

--- a/js/ui/buttonHandlers.js
+++ b/js/ui/buttonHandlers.js
@@ -1,6 +1,6 @@
 import trainingState, { saveState } from "../core/trainingState.js";
 import { autoProgressWeeklyVolume } from "../algorithms/effort.js";
-import { startWorkout, validateWorkoutStart, logSet, undoLastSet } from "../algorithms/workout.js";
+import { startWorkout, validateWorkoutStart, logSet, undoLastSet, finishWorkout } from "../algorithms/workout.js";
 
 export function beginnerPreset() {
   console.log("Beginner preset selected");
@@ -483,3 +483,32 @@ window["btnPlateauAnalysis"] = plateauAnalysis;
 window["btnStartLiveSession"] = startWorkoutHandler;
 window["btnLogSet"] = logSetHandler;
 window["btnUndoLastSet"] = undoLastSetHandler;
+window["btnFinishWorkout"] = finishWorkoutHandler;
+
+export function finishWorkoutHandler() {
+  console.log("Finishing workout session");
+
+  const currentWorkout = trainingState.currentWorkout;
+  if (!currentWorkout || currentWorkout.status !== 'active') {
+    console.error("No active workout session");
+    window.dispatchEvent(new CustomEvent("workout-finish-failed", {
+      detail: { error: "No active workout session. Please start a workout first." }
+    }));
+    return;
+  }
+
+  try {
+    const finishedSession = finishWorkout(currentWorkout, trainingState);
+    saveState();
+    window.dispatchEvent(new CustomEvent("workout-finished", {
+      detail: { session: finishedSession }
+    }));
+    console.log("Workout session finished successfully:", finishedSession.id);
+  } catch (error) {
+    console.error("Failed to finish workout:", error.message);
+    window.dispatchEvent(new CustomEvent("workout-finish-failed", {
+      detail: { error: error.message }
+    }));
+  }
+}
+window.btnFinishWorkout = finishWorkoutHandler;

--- a/js/ui/globals.js
+++ b/js/ui/globals.js
@@ -22,7 +22,8 @@ import {
   plateauAnalysis,
   startWorkoutHandler,
   logSetHandler,
-  undoLastSetHandler
+  undoLastSetHandler,
+  finishWorkoutHandler
 } from "./buttonHandlers.js";
 
 import {
@@ -1567,6 +1568,7 @@ document.getElementById("btnPlateauAnalysis")?.addEventListener("click", window.
 document.getElementById("btnStartLiveSession")?.addEventListener("click", window.btnStartLiveSession);
 document.getElementById("btnLogSet")?.addEventListener("click", window.btnLogSet);
 document.getElementById("btnUndoLastSet")?.addEventListener("click", window.btnUndoLastSet);
+document.getElementById("btnFinishWorkout")?.addEventListener("click", window.btnFinishWorkout);
 
 // Ensure all Phase-2 button handlers are exposed for audit script compatibility
 window.btnSetupMesocycle = window.btnSetupMesocycle || window.setupMesocycle;
@@ -1587,6 +1589,7 @@ window.btnPlateauAnalysis = window.btnPlateauAnalysis || window.plateauAnalysis;
 window.btnStartLiveSession = window.btnStartLiveSession || window.startWorkoutHandler;
 window.btnLogSet = window.btnLogSet || window.logSetHandler;
 window.btnUndoLastSet = window.btnUndoLastSet || window.undoLastSetHandler;
+window.btnFinishWorkout = window.btnFinishWorkout || window.finishWorkoutHandler;
 
 // Initialize navigation system
 initNavigation();

--- a/tests/finishWorkout.test.js
+++ b/tests/finishWorkout.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+import { finishWorkout } from '../js/algorithms/workout.js';
+import { finishWorkoutHandler } from '../js/ui/buttonHandlers.js';
+import trainingState from '../js/core/trainingState.js';
+
+describe('finishWorkout algorithm', () => {
+  beforeEach(() => {
+    trainingState.currentWorkout = {
+      id: 'test-session',
+      status: 'active',
+      exercises: [],
+      totalSets: 0,
+      totalVolume: 0
+    };
+    trainingState.workoutHistory = [];
+  });
+
+  test('should move session to history and clear current', () => {
+    const session = trainingState.currentWorkout;
+    const result = finishWorkout();
+
+    expect(result).toBe(session);
+    expect(result.status).toBe('completed');
+    expect(trainingState.workoutHistory).toContain(session);
+    expect(trainingState.currentWorkout).toBeNull();
+    expect(result.endTime).toBeDefined();
+  });
+});
+
+describe('finishWorkoutHandler integration', () => {
+  beforeEach(() => {
+    trainingState.currentWorkout = {
+      id: 'handler-session',
+      status: 'active',
+      exercises: []
+    };
+    trainingState.workoutHistory = [];
+    window.dispatchEvent = jest.fn();
+  });
+
+  test('should dispatch workout-finished event and clear state', () => {
+    finishWorkoutHandler();
+
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'workout-finished',
+        detail: expect.objectContaining({ session: expect.any(Object) })
+      })
+    );
+    expect(trainingState.currentWorkout).toBeNull();
+    expect(trainingState.workoutHistory).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- support finishing workouts in workout algorithm
- add finishWorkoutHandler and expose through globals
- wire up #btnFinishWorkout and update button inventory
- add finishWorkout tests

## Testing
- `node scripts/report-missing-handlers.js | tail -n 20`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546e47318c8323a9c9ac072c84ed98