### PR TITLE
Remove remaining jest imports

### DIFF
--- a/__tests__/logSet.test.js
+++ b/__tests__/logSet.test.js
@@ -3,7 +3,7 @@
  * Tests for Phase-4 set logging functionality
  */
 
-import { jest } from '@jest/globals';
+import { vi } from 'vitest';
 
 // Mock the trainingState module
 const mockTrainingState = {
@@ -21,7 +21,7 @@ const mockTrainingState = {
 // Mock the core module
 jest.unstable_mockModule('../js/core/trainingState.js', () => ({
   default: mockTrainingState,
-  saveState: jest.fn()
+  saveState: vi.fn()
 }));
 
 // Import the modules after mocking

--- a/__tests__/undoLastSet.test.js
+++ b/__tests__/undoLastSet.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { jest } from '@jest/globals';
+import { vi } from 'vitest';
 
 import { undoLastSet } from '../js/algorithms/workout.js';
 import { undoLastSetHandler } from '../js/ui/buttonHandlers.js';
@@ -267,7 +267,7 @@ describe('UndoLastSet Handler Integration', () => {
     beforeEach(() => {
     // Mock DOM events
     global.window = Object.create(window);
-    const mockDispatchEvent = jest.fn();
+    const mockDispatchEvent = vi.fn();
     global.window.dispatchEvent = mockDispatchEvent;
     window.dispatchEvent = mockDispatchEvent;
     
@@ -302,8 +302,8 @@ describe('UndoLastSet Handler Integration', () => {
     // Reset training state
     trainingState.currentWorkout = null;
       // Mock console methods
-    const mockConsoleLog = jest.fn();
-    const mockConsoleError = jest.fn();
+    const mockConsoleLog = vi.fn();
+    const mockConsoleError = vi.fn();
     console.log = mockConsoleLog;
     console.error = mockConsoleError;
   });

--- a/__tests__/workout.test.js
+++ b/__tests__/workout.test.js
@@ -3,7 +3,7 @@
  * Tests for Phase-4 workout session management
  */
 
-import { jest } from '@jest/globals';
+import { vi } from 'vitest';
 
 // Mock the trainingState module
 const mockTrainingState = {
@@ -21,7 +21,7 @@ const mockTrainingState = {
 // Mock the core module
 jest.unstable_mockModule('../js/core/trainingState.js', () => ({
   default: mockTrainingState,
-  saveState: jest.fn()
+  saveState: vi.fn()
 }));
 
 // Import the modules after mocking

--- a/tests/dataMgmt.test.js
+++ b/tests/dataMgmt.test.js
@@ -4,14 +4,15 @@
 
 import * as ts from "../js/core/trainingState.js";
 import { exportAllData, exportChart, createBackup, autoBackup, importData, exportFeedback } from "../js/algorithms/dataExport.js";
+import { vi } from 'vitest';
 
 // Mock file system operations for testing
 global.URL = {
-  createObjectURL: jest.fn(() => 'mock-object-url'),
-  revokeObjectURL: jest.fn()
+  createObjectURL: vi.fn(() => 'mock-object-url'),
+  revokeObjectURL: vi.fn()
 };
 
-global.Blob = jest.fn((content, options) => ({
+global.Blob = vi.fn((content, options) => ({
   content,
   options,
   size: content[0].length,
@@ -19,12 +20,12 @@ global.Blob = jest.fn((content, options) => ({
 }));
 
 // Mock DOM elements
-document.createElement = jest.fn((tagName) => {
+document.createElement = vi.fn((tagName) => {
   const element = {
     tagName: tagName.toUpperCase(),
-    click: jest.fn(),
-    setAttribute: jest.fn(),
-    getAttribute: jest.fn(),
+    click: vi.fn(),
+    setAttribute: vi.fn(),
+    getAttribute: vi.fn(),
     style: {},
     href: '',
     download: ''
@@ -40,8 +41,8 @@ document.createElement = jest.fn((tagName) => {
 });
 
 document.body = {
-  appendChild: jest.fn(),
-  removeChild: jest.fn()
+  appendChild: vi.fn(),
+  removeChild: vi.fn()
 };
 
 // ----- isolate global singleton so later test-suites aren't polluted -----
@@ -54,7 +55,7 @@ beforeEach(() => {
   }
   
   // Reset mocks
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 afterAll(() => {

--- a/tests/finishWorkout.test.js
+++ b/tests/finishWorkout.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { jest } from '@jest/globals';
+import { vi } from 'vitest';
 
 import { finishWorkout } from '../js/algorithms/workout.js';
 import { finishWorkoutHandler } from '../js/ui/buttonHandlers.js';
@@ -39,7 +39,7 @@ describe('finishWorkoutHandler integration', () => {
       exercises: []
     };
     trainingState.workoutHistory = [];
-    window.dispatchEvent = jest.fn();
+    window.dispatchEvent = vi.fn();
   });
 
   test('should dispatch workout-finished event and clear state', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({  test: {
     environment: "jsdom",
     globals: true,                        // Enable global test functions (describe, it, expect, etc.)
+
+    setupFiles: ['./vitest.setup.js'],
     
     // 🎯 Specify which test files to run
     include: ["tests/**/*.{test,spec}.{js,jsx}", "__tests__/**/*.{test,spec}.{js,jsx}"],

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,7 @@
+import { vi } from 'vitest';
+
+// temporary shim for legacy Jest calls
+globalThis.jest = vi;
+
+// ensure ts-node/globals parity if needed
+globalThis.afterAll = afterAll;


### PR DESCRIPTION
## Summary
- shim global `jest` using vitest
- wire vitest setup file in `vitest.config.js`
- swap remaining spec imports from Jest to Vitest

## Testing
- `pnpm run verify` *(fails: state.getWeeklySets is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68575a8b37f4832398fb406770c6dcf6