### PR TITLE
Extend training-state mock in tests

### DIFF
--- a/__tests__/__mocks__/trainingState.js
+++ b/__tests__/__mocks__/trainingState.js
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+
+export const mockTrainingState = {
+  getWeeklySets: vi.fn(() => 10),
+  getTotalWeeklyVolume: vi.fn(() => 15000),
+};
+
+export function resetMockTrainingState () {
+  mockTrainingState.getWeeklySets.mockReset();
+  mockTrainingState.getTotalWeeklyVolume.mockReset();
+  mockTrainingState.getWeeklySets.mockReturnValue(10);
+  mockTrainingState.getTotalWeeklyVolume.mockReturnValue(15000);
+}
+
+export default mockTrainingState;

--- a/__tests__/helpers/mockState.js
+++ b/__tests__/helpers/mockState.js
@@ -1,0 +1,3 @@
+import { mockTrainingState, resetMockTrainingState } from '../__mocks__/trainingState.js';
+
+export { mockTrainingState, resetMockTrainingState };

--- a/__tests__/logSet.test.js
+++ b/__tests__/logSet.test.js
@@ -3,7 +3,7 @@
  * Tests for Phase-4 set logging functionality
  */
 
-import { jest } from '@jest/globals';
+import { vi as jest } from 'vitest';
 
 // Mock the trainingState module
 const mockTrainingState = {

--- a/__tests__/undoLastSet.test.js
+++ b/__tests__/undoLastSet.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { jest } from '@jest/globals';
+import { vi as jest } from 'vitest';
 
 import { undoLastSet } from '../js/algorithms/workout.js';
 import { undoLastSetHandler } from '../js/ui/buttonHandlers.js';

--- a/__tests__/workout.test.js
+++ b/__tests__/workout.test.js
@@ -3,7 +3,7 @@
  * Tests for Phase-4 workout session management
  */
 
-import { jest } from '@jest/globals';
+import { vi as jest } from 'vitest';
 
 // Mock the trainingState module
 const mockTrainingState = {

--- a/tests/deload.test.js
+++ b/tests/deload.test.js
@@ -3,17 +3,14 @@
  */
 
 import * as ts from "../js/core/trainingState.js";
+import { mockTrainingState as state } from "../__tests__/__mocks__/trainingState.js";
+import { resetMockTrainingState } from "../__tests__/helpers/mockState.js";
 import { analyzeDeloadNeed, initializeAtMEV } from "../js/algorithms/deload.js";
 
 // ----- isolate global singleton so later test-suites aren't polluted -----
 const snapshot = ts.trainingState ? Object.assign({}, ts.trainingState) : {};
 
-beforeEach(() => {
-  // start every test with a fresh clone of the pristine snapshot
-  if (ts.trainingState) {
-    Object.assign(ts.trainingState, Object.assign({}, snapshot));
-  }
-});
+beforeEach(resetMockTrainingState);
 
 afterAll(() => {
   // restore original once the whole file is done
@@ -25,6 +22,7 @@ afterAll(() => {
 describe('Deload Algorithm Tests', () => {
   describe('analyzeDeloadNeed', () => {
     const mockTrainingState = {
+      ...state,
       currentMesocycle: {
         currentWeek: 4,
         length: 6
@@ -116,6 +114,7 @@ describe('Deload Algorithm Tests', () => {
 
   describe('initializeAtMEV', () => {
     const mockTrainingState = {
+      ...state,
       volumeLandmarks: {
         chest: { mv: 8, mev: 10, mav: 16, mrv: 20 },
         back: { mv: 6, mev: 8, mav: 14, mrv: 18 },
@@ -188,6 +187,7 @@ describe('Deload Algorithm Tests', () => {
   describe('Integration Tests', () => {
     test('should work together for complete deload cycle', () => {
       const trainingState = {
+        ...state,
         currentMesocycle: { currentWeek: 5, length: 6 },
         weeklyProgram: {
           actualVolume: {

--- a/tests/finishWorkout.test.js
+++ b/tests/finishWorkout.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { jest } from '@jest/globals';
+import { vi as jest } from 'vitest';
 
 import { finishWorkout } from '../js/algorithms/workout.js';
 import { finishWorkoutHandler } from '../js/ui/buttonHandlers.js';

--- a/tests/intelligence.test.js
+++ b/tests/intelligence.test.js
@@ -3,17 +3,14 @@
  */
 
 import * as ts from "../js/core/trainingState.js";
+import { mockTrainingState as state } from "../__tests__/__mocks__/trainingState.js";
+import { resetMockTrainingState } from "../__tests__/helpers/mockState.js";
 import { initIntelligence, optimizeVolumeLandmarks, adaptiveRIRRecommendations } from "../js/algorithms/intelligence.js";
 
 // ----- isolate global singleton so later test-suites aren't polluted -----
 const snapshot = ts.trainingState ? Object.assign({}, ts.trainingState) : {};
 
-beforeEach(() => {
-  // start every test with a fresh clone of the pristine snapshot
-  if (ts.trainingState) {
-    Object.assign(ts.trainingState, Object.assign({}, snapshot));
-  }
-});
+beforeEach(resetMockTrainingState);
 
 afterAll(() => {
   // restore original once the whole file is done
@@ -25,6 +22,7 @@ afterAll(() => {
 describe('Intelligence Algorithm Tests', () => {
   describe('initIntelligence', () => {
     const mockTrainingState = {
+      ...state,
       currentMesocycle: {
         currentWeek: 3,
         length: 6
@@ -95,6 +93,7 @@ describe('Intelligence Algorithm Tests', () => {
 
   describe('optimizeVolumeLandmarks', () => {
     const mockTrainingState = {
+      ...state,
       currentMesocycle: {
         currentWeek: 4,
         length: 6
@@ -181,6 +180,7 @@ describe('Intelligence Algorithm Tests', () => {
 
   describe('adaptiveRIRRecommendations', () => {
     const mockTrainingState = {
+      ...state,
       currentMesocycle: {
         currentWeek: 3,
         length: 6,
@@ -291,6 +291,7 @@ describe('Intelligence Algorithm Tests', () => {
   describe('Integration Tests', () => {
     test('should work together for complete intelligence workflow', () => {
       const trainingState = {
+        ...state,
         currentMesocycle: { currentWeek: 3, length: 6, phase: 'accumulation' },
         weeklyProgram: {
           actualVolume: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({  test: {
+export default defineConfig({
+  test: {
+    setupFiles: ["./vitest.setup.js"],
     environment: "jsdom",
     globals: true,                        // Enable global test functions (describe, it, expect, etc.)
     

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,4 @@
+import { vi } from 'vitest';
+
+// Provide jest global for compatibility with older tests
+global.jest = vi;


### PR DESCRIPTION
## Summary
- mock trainingState with spies for getWeeklySets and getTotalWeeklyVolume
- reset spies before each algorithm test
- update algorithm specs to use the new mock
- move Vitest setup file into test block and shim `jest` global
- remove remaining `@jest/globals` imports

## Testing
- `pnpm run verify` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575a97f1f08323a9915c33e775cbf3