### PR TITLE
Fix CI workflow to use pnpm

### DIFF
--- a/.github/workflows/formula-validation.yml
+++ b/.github/workflows/formula-validation.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: npm ci
+      - name: Install pnpm
+        run: npm install -g pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Run full CI
         run: npm run ci


### PR DESCRIPTION
## Summary
- replace `npm ci` with `pnpm install --frozen-lockfile`
- install pnpm in formula-validation workflow

## Testing
- `npm install`
- `npm test` *(fails: Test Files 33 failed | 67 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686490d64ef8832397127b0def4f8a16