### PR TITLE
fix lint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",
     "eslint": "^9.29.0",
+    "@eslint/js": "^9.29.0",
+    "globals": "^16.2.0",
     "eslint-config-prettier": "^10.1.5",
     "fake-indexeddb": "^4.0.2",
     "jest": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^4.5.2
         version: 4.5.7(@types/react@19.1.8)(react@19.1.0)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.29.0
+        version: 9.29.0
       '@parcel/packager-raw-url':
         specifier: ^2.15.2
         version: 2.15.2(@parcel/core@2.15.2(@swc/helpers@0.5.17))
@@ -81,6 +84,9 @@ importers:
       fake-indexeddb:
         specifier: ^4.0.2
         version: 4.0.2
+      globals:
+        specifier: ^16.2.0
+        version: 16.2.0
       jest:
         specifier: ^30.0.0
         version: 30.0.2(@types/node@24.0.3)


### PR DESCRIPTION
## Summary
- add `@eslint/js` and `globals` to root devDependencies
- refresh lockfile

## Testing
- `pnpm run lint:ci`

------
https://chatgpt.com/codex/tasks/task_e_68670e5628e48323a4f836121f246f02