### PR TITLE
Add test environment configuration

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://test.supabase.co
+VITE_SUPABASE_ANON_KEY=test-anon-key

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",
+    "dotenv": "^17.0.1",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "fake-indexeddb": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      dotenv:
+        specifier: ^17.0.1
+        version: 17.0.1
       eslint:
         specifier: ^9.29.0
         version: 9.29.0(jiti@2.4.2)
@@ -2975,6 +2978,10 @@ packages:
 
   dotenv@16.5.0:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+    engines: {node: '>=12'}
+
+  dotenv@17.0.1:
+    resolution: {integrity: sha512-GLjkduuAL7IMJg/ZnOPm9AnWKJ82mSE2tzXLaJ/6hD6DhwGfZaXG77oB8qbReyiczNxnbxQKyh0OE5mXq0bAHA==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -8280,6 +8287,8 @@ snapshots:
       dotenv: 16.5.0
 
   dotenv@16.5.0: {}
+
+  dotenv@17.0.1: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config'
-import { fileURLToPath } from 'url';
-import path from 'path';
+import { fileURLToPath } from 'url'
+import path from 'path'
+import dotenv from 'dotenv'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+if (process.env.NODE_ENV === 'test') {
+  dotenv.config({ path: path.join(__dirname, '.env.test') })
+}
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- add `.env.test` placeholder values
- load `.env.test` in `vitest.config.js` when `NODE_ENV=test`
- install `dotenv` for env management

## Testing
- `pnpm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68670e5d9d248323920d92608b06683a